### PR TITLE
6 change transportnewlistener to use multiaddrmultiaddr instead of string

### DIFF
--- a/pkg/codec/ad/addresses/addresses.go
+++ b/pkg/codec/ad/addresses/addresses.go
@@ -9,7 +9,6 @@ import (
 	"github.com/indra-labs/indra/pkg/crypto"
 	"github.com/indra-labs/indra/pkg/crypto/nonce"
 	log2 "github.com/indra-labs/indra/pkg/proc/log"
-	"github.com/indra-labs/indra/pkg/util/multi"
 	"github.com/indra-labs/indra/pkg/util/slice"
 	"github.com/indra-labs/indra/pkg/util/splice"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -109,17 +108,18 @@ func (x *Ad) Len() int {
 
 	l := ad.Len + slice.Uint16Len
 	// Generate the addresses to get their data length:
-	for _, v := range x.Addresses {
-		var b []byte
-		var e error
-		b, e = multi.AddrToBytes(v, cfg.GetCurrentDefaultPort())
-		if fails(e) {
-			panic(e)
-		}
-		log.D.S("bytes", b)
-		l += len(b) + 1
-	}
-	log.D.Ln(l)
+	// for _, v := range x.Addresses {
+	// var b []byte
+	// var e error
+	// b, e = multi.AddrToBytes(v, cfg.GetCurrentDefaultPort())
+	// if fails(e) {
+	// 	panic(e)
+	// }
+	// log.D.S("bytes", b)
+	// l += 21 // len(b) + 1
+	// }
+	l += 21 * len(x.Addresses)
+	// log.D.Ln(l)
 	return l
 }
 
@@ -157,21 +157,21 @@ func (x *Ad) SpliceNoSig(s *splice.Splice) {
 func Splice(s *splice.Splice, id nonce.ID, key *crypto.Pub,
 	addrs []multiaddr.Multiaddr, expiry time.Time) {
 
-	log.D.Ln("spliced", s.GetCursor())
+	// log.D.Ln("spliced", s.GetCursor())
 	s.Magic(Magic)
-	log.D.Ln("spliced", s.GetCursor(), "magic")
+	// log.D.Ln("spliced", s.GetCursor(), "magic")
 	s.ID(id)
-	log.D.Ln("spliced", s.GetCursor(), "ID")
+	// log.D.Ln("spliced", s.GetCursor(), "ID")
 	s.Pubkey(key)
-	log.D.Ln("spliced", s.GetCursor(), "pubkey")
+	// log.D.Ln("spliced", s.GetCursor(), "pubkey")
 	s.Uint16(uint16(len(addrs)))
-	log.D.Ln("spliced", s.GetCursor(), "addrlen")
+	// log.D.Ln("spliced", s.GetCursor(), "addrlen")
 	for i := range addrs {
 		s.Multiaddr(addrs[i], cfg.GetCurrentDefaultPort())
-		log.D.Ln("addresses", s.GetCursor(), "addr", i)
+		// log.D.Ln("addresses", s.GetCursor(), "addr", i)
 	}
 	s.Time(expiry)
-	log.D.Ln("spliced", s.GetCursor(), "bytes")
+	// log.D.Ln("spliced", s.GetCursor(), "bytes")
 }
 
 func init() { reg.Register(Magic, Gen) }

--- a/pkg/codec/ad/addresses/addresses.go
+++ b/pkg/codec/ad/addresses/addresses.go
@@ -104,6 +104,9 @@ func (x *Ad) Unwrap() interface{} { return nil }
 // Len returns the length of bytes required to encode the Ad, based on the number
 // of Addresses inside it.
 func (x *Ad) Len() int {
+
+	codec.MustNotBeNil(x)
+
 	l := ad.Len + slice.Uint16Len
 	// Generate the addresses to get their data length:
 	for _, v := range x.Addresses {

--- a/pkg/codec/ad/addresses/addresses_test.go
+++ b/pkg/codec/ad/addresses/addresses_test.go
@@ -29,7 +29,9 @@ func TestNew(t *testing.T) {
 	}
 	aa := New(id, pr, []multiaddr.Multiaddr{ma4, ma6},
 		time.Now().Add(time.Hour*24*7))
-	s := splice.New(aa.Len())
+	l := aa.Len()
+	log.I.Ln("l", l)
+	s := splice.New(l)
 	if e = aa.Encode(s); fails(e) {
 		t.FailNow()
 	}

--- a/pkg/codec/ad/addresses/addresses_test.go
+++ b/pkg/codec/ad/addresses/addresses_test.go
@@ -7,10 +7,8 @@ import (
 	"github.com/indra-labs/indra/pkg/crypto"
 	"github.com/indra-labs/indra/pkg/crypto/nonce"
 	log2 "github.com/indra-labs/indra/pkg/proc/log"
-	"github.com/indra-labs/indra/pkg/util/multi"
 	"github.com/indra-labs/indra/pkg/util/splice"
 	"github.com/multiformats/go-multiaddr"
-	"net/netip"
 	"testing"
 	"time"
 )
@@ -29,14 +27,8 @@ func TestNew(t *testing.T) {
 	if ma6, e = multiaddr.NewMultiaddr("/ip6/::1/tcp/4242"); fails(e) {
 		t.FailNow()
 	}
-	var ap4, ap6 netip.AddrPort
-	if ap4, e = multi.AddrToAddrPort(ma4); fails(e) {
-		t.FailNow()
-	}
-	if ap6, e = multi.AddrToAddrPort(ma6); fails(e) {
-		t.FailNow()
-	}
-	aa := New(id, pr, []*netip.AddrPort{&ap4, &ap6}, time.Now().Add(time.Hour*24*7))
+	aa := New(id, pr, []multiaddr.Multiaddr{ma4, ma6},
+		time.Now().Add(time.Hour*24*7))
 	s := splice.New(aa.Len())
 	if e = aa.Encode(s); fails(e) {
 		t.FailNow()
@@ -67,7 +59,7 @@ func TestNew(t *testing.T) {
 		t.FailNow()
 	}
 	for i := range ad.Addresses {
-		if *ad.Addresses[i] != *aa.Addresses[i] {
+		if ad.Addresses[i].String() != aa.Addresses[i].String() {
 			t.Errorf("address did not decode correctly")
 			t.FailNow()
 		}

--- a/pkg/codec/ad/intro/intro.go
+++ b/pkg/codec/ad/intro/intro.go
@@ -84,7 +84,12 @@ func (x *Ad) Encode(s *splice.Splice) (e error) {
 func (x *Ad) Unwrap() interface{} { return nil }
 
 // Len returns the length of the binary encoded Ad.
-func (x *Ad) Len() int { return Len }
+func (x *Ad) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len
+}
 
 // Magic is the identifier indicating an Ad is encoded in the following bytes.
 func (x *Ad) Magic() string { return Magic }

--- a/pkg/codec/ad/load/load.go
+++ b/pkg/codec/ad/load/load.go
@@ -86,7 +86,12 @@ func (x *Ad) Encode(s *splice.Splice) (e error) {
 func (x *Ad) Unwrap() interface{} { return nil }
 
 // Len is the number of bytes required for the binary encoded form of an Ad.
-func (x *Ad) Len() int { return Len }
+func (x *Ad) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len
+}
 
 // Magic is the identifying 4 byte string used to mark the beginning of a message
 // and designate the type.

--- a/pkg/codec/ad/peer/peer.go
+++ b/pkg/codec/ad/peer/peer.go
@@ -99,7 +99,12 @@ func (x *Ad) Encode(s *splice.Splice) (e error) {
 func (x *Ad) Unwrap() interface{} { return nil }
 
 // Len returns the length of the binary encoded Ad.
-func (x *Ad) Len() int { return Len }
+func (x *Ad) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len
+}
 
 // Magic is the identifier indicating an Ad is encoded in the following bytes.
 func (x *Ad) Magic() string { return "" }

--- a/pkg/codec/ad/services/services.go
+++ b/pkg/codec/ad/services/services.go
@@ -107,7 +107,12 @@ func (x *Ad) Unwrap() interface{} { return nil }
 // Len returns the length of the binary encoded Ad.
 //
 // This gives different values depending on how many services are listed.
-func (x *Ad) Len() int { return ad.Len + len(x.Services)*Len + slice.Uint32Len }
+func (x *Ad) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return ad.Len + len(x.Services)*Len + slice.Uint32Len
+}
 
 // Magic is the identifier indicating an Ad is encoded in the following bytes.
 func (x *Ad) Magic() string { return "" }

--- a/pkg/codec/interfaces.go
+++ b/pkg/codec/interfaces.go
@@ -4,16 +4,39 @@
 package codec
 
 import (
+	log2 "github.com/indra-labs/indra/pkg/proc/log"
 	"github.com/indra-labs/indra/pkg/util/splice"
+)
+
+var (
+	log   = log2.GetLogger()
+	fails = log.E.Chk
 )
 
 // Codec is a unit of data that can be read and written from a binary form. All
 // Onion are Codec but not all Codec are Onion. Codec is also used for the
 // Dispatcher's message headers.
 type Codec interface {
+
+	// Magic is a 4 byte string identifying the type of the following message bytes.
 	Magic() string
+
+	// Encode uses the Codec's contents to encode into the splice.Splice next bytes.
 	Encode(s *splice.Splice) (e error)
+
+	// Decode reads in the data in the next bytes of the splice.Splice to populate this Codec.
 	Decode(s *splice.Splice) (e error)
+
+	// Len returns the number of bytes required to encode this Codec message (including Magic).
 	Len() int
+
+	// Unwrap gives access to any further layers embedded inside this (specifically, the Onion inside).
 	Unwrap() interface{}
+}
+
+// Encode is the generic encoder for a Codec, all can be encoded with it.
+func Encode(d Codec) (s *splice.Splice) {
+	s = splice.New(d.Len())
+	fails(d.Encode(s))
+	return
 }

--- a/pkg/codec/interfaces.go
+++ b/pkg/codec/interfaces.go
@@ -28,10 +28,19 @@ type Codec interface {
 	Decode(s *splice.Splice) (e error)
 
 	// Len returns the number of bytes required to encode this Codec message (including Magic).
+	//
+	// This function must panic if called on a nil pointer as unconfigured
+	// messages cannot yield a valid length value in many cases.
 	Len() int
 
 	// Unwrap gives access to any further layers embedded inside this (specifically, the Onion inside).
 	Unwrap() interface{}
+}
+
+func MustNotBeNil(c Codec) {
+	if c == nil {
+		panic("cannot compute length without struct fields")
+	}
 }
 
 // Encode is the generic encoder for a Codec, all can be encoded with it.

--- a/pkg/codec/onion/cores/balance/balance.go
+++ b/pkg/codec/onion/cores/balance/balance.go
@@ -115,7 +115,12 @@ func (x *Balance) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 }
 
 // Len returns the length of bytes required to encode the Balance.
-func (x *Balance) Len() int { return Len }
+func (x *Balance) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len
+}
 
 // Magic bytes that identify this message.
 func (x *Balance) Magic() string { return Magic }

--- a/pkg/codec/onion/cores/balance/balance_test.go
+++ b/pkg/codec/onion/cores/balance/balance_test.go
@@ -20,7 +20,7 @@ func TestOnions_Balance(t *testing.T) {
 	id := nonce.NewID()
 	sats := lnwire.MilliSatoshi(10000)
 	on := ont.Assemble([]ont.Onion{New(id, sats)})
-	s := ont.Encode(on)
+	s := codec.Encode(on)
 	s.SetCursor(0)
 	var onc codec.Codec
 	if onc = reg.Recognise(s); onc == nil {

--- a/pkg/codec/onion/cores/confirmation/confirmation.go
+++ b/pkg/codec/onion/cores/confirmation/confirmation.go
@@ -70,7 +70,12 @@ func (x *Confirmation) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e err
 }
 
 // Len returns the length of bytes required to encode the Confirmation.
-func (x *Confirmation) Len() int { return Len }
+func (x *Confirmation) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len
+}
 
 // Magic bytes that identify this message
 func (x *Confirmation) Magic() string { return Magic }

--- a/pkg/codec/onion/cores/confirmation/confirmation_test.go
+++ b/pkg/codec/onion/cores/confirmation/confirmation_test.go
@@ -17,7 +17,7 @@ func TestOnions_Confirmation(t *testing.T) {
 	}
 	id := nonce.NewID()
 	on := ont.Assemble([]ont.Onion{New(id)})
-	s := ont.Encode(on)
+	s := codec.Encode(on)
 	s.SetCursor(0)
 	var onc codec.Codec
 	if onc = reg.Recognise(s); onc == nil {

--- a/pkg/codec/onion/cores/end/template.go
+++ b/pkg/codec/onion/cores/end/template.go
@@ -27,8 +27,13 @@ func (x *End) Encode(s *splice.Splice) (e error)                           { ret
 func EndGen() codec.Codec                                                  { return &End{} }
 func (x *End) Unwrap() interface{}                                         { return x }
 func (x *End) Handle(s *splice.Splice, p ont.Onion, ni ont.Ngin) (e error) { return }
-func (x *End) Len() int                                                    { return Len }
-func (x *End) Magic() string                                               { return Magic }
-func (x *End) Wrap(inner ont.Onion)                                        {}
-func NewEnd() *End                                                         { return &End{} }
-func init()                                                                { reg.Register(Magic, EndGen) }
+func (x *End) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len
+}
+func (x *End) Magic() string        { return Magic }
+func (x *End) Wrap(inner ont.Onion) {}
+func NewEnd() *End                  { return &End{} }
+func init()                         { reg.Register(Magic, EndGen) }

--- a/pkg/codec/onion/cores/response/response.go
+++ b/pkg/codec/onion/cores/response/response.go
@@ -123,7 +123,12 @@ func (x *Response) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) 
 
 // Len returns the length of the onion starting from this one (used to size a
 // Splice).
-func (x *Response) Len() int { return Len + len(x.Bytes) }
+func (x *Response) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len + len(x.Bytes)
+}
 
 // Magic bytes identifying a HiddenService message is up next.
 func (x *Response) Magic() string { return Magic }

--- a/pkg/codec/onion/cores/response/response_test.go
+++ b/pkg/codec/onion/cores/response/response_test.go
@@ -28,7 +28,7 @@ func TestOnions_Response(t *testing.T) {
 		New(id, port, msg, 0),
 		end.NewEnd(),
 	})
-	s := ont.Encode(on)
+	s := codec.Encode(on)
 	s.SetCursor(0)
 	var onc codec.Codec
 	if onc = reg.Recognise(s); onc == nil {

--- a/pkg/codec/onion/crypt/crypt.go
+++ b/pkg/codec/onion/crypt/crypt.go
@@ -153,6 +153,9 @@ func (x *Crypt) Unwrap() interface{} { return x }
 // Handle provides relay and accounting processing logic for receiving a Crypt
 // message.
 func (x *Crypt) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
+
+	// todo: get the payload key also, and read ahead for an offset, and apply
+
 	hdr, _, _, identity := ng.Mgr().FindCloaked(x.Cloak)
 	if hdr == nil {
 		log.T.Ln("no matching key found from cloaked key")
@@ -166,9 +169,8 @@ func (x *Crypt) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 				" no following session")
 			return e
 		}
-		ng.HandleMessage(splice.BudgeUp(s), x)
-		return e
 	}
+
 	ng.HandleMessage(splice.BudgeUp(s), x)
 	return e
 }

--- a/pkg/codec/onion/crypt/crypt.go
+++ b/pkg/codec/onion/crypt/crypt.go
@@ -174,7 +174,12 @@ func (x *Crypt) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 }
 
 // Len returns the length of bytes required to encode the Crypt.
-func (x *Crypt) Len() int { return consts.CryptLen + x.Onion.Len() }
+func (x *Crypt) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return consts.CryptLen + x.Onion.Len()
+}
 
 // Magic bytes that identify this message
 func (x *Crypt) Magic() string { return CryptMagic }

--- a/pkg/codec/onion/crypt/crypt_test.go
+++ b/pkg/codec/onion/crypt/crypt_test.go
@@ -26,7 +26,7 @@ func TestOnions_SimpleCrypt(t *testing.T) {
 		New(pub1, pub2, prv2, n1, 0),
 		confirmation.New(n),
 	})
-	s := ont.Encode(on)
+	s := codec.Encode(on)
 	s.SetCursor(0)
 	log.D.S("encoded, encrypted onion:\n", s.GetAll().ToBytes())
 	var oncr codec.Codec

--- a/pkg/codec/onion/delay/delay.go
+++ b/pkg/codec/onion/delay/delay.go
@@ -76,7 +76,12 @@ func (x *Delay) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 }
 
 // Len returns the length of bytes required to encode this Delay.
-func (x *Delay) Len() int { return Len + x.Onion.Len() }
+func (x *Delay) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len + x.Onion.Len()
+}
 
 // Magic bytes that identify this message.
 func (x *Delay) Magic() string { return Magic }

--- a/pkg/codec/onion/delay/delay_test.go
+++ b/pkg/codec/onion/delay/delay_test.go
@@ -17,7 +17,7 @@ func TestOnions_Delay(t *testing.T) {
 	}
 	dur := time.Second
 	on := ont.Assemble([]ont.Onion{New(dur)})
-	s := ont.Encode(on)
+	s := codec.Encode(on)
 	s.SetCursor(0)
 	var onc codec.Codec
 	if onc = reg.Recognise(s); onc == nil {

--- a/pkg/codec/onion/exit/exit.go
+++ b/pkg/codec/onion/exit/exit.go
@@ -140,7 +140,7 @@ func (x *Exit) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 	case <-timer.C:
 	}
 	// We need to wrap the result in a message crypt.
-	res := ont.Encode(&response.Response{
+	res := codec.Encode(&response.Response{
 		ID:    x.ID,
 		Port:  x.Port,
 		Load:  byte(ng.GetLoad()),
@@ -173,7 +173,12 @@ func (x *Exit) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 
 // Len returns the length of this Exit message (payload and return header Onion
 // included.
-func (x *Exit) Len() int { return Len + x.Bytes.Len() + x.Onion.Len() }
+func (x *Exit) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len + x.Bytes.Len() + x.Onion.Len()
+}
 
 // Magic is the identifying 4 byte string indicating an Exit message follows.
 func (x *Exit) Magic() string { return Magic }

--- a/pkg/codec/onion/exit/exit_test.go
+++ b/pkg/codec/onion/exit/exit_test.go
@@ -37,7 +37,7 @@ func TestOnions_Exit(t *testing.T) {
 		ReturnPubs: pubs,
 	}
 	on := ont.Assemble([]ont.Onion{New(id, p, msg, ep)})
-	s := ont.Encode(on)
+	s := codec.Encode(on)
 	s.SetCursor(0)
 	var onc codec.Codec
 	if onc = reg.Recognise(s); onc == nil {

--- a/pkg/codec/onion/forward/forward.go
+++ b/pkg/codec/onion/forward/forward.go
@@ -4,6 +4,7 @@
 package forward
 
 import (
+	"github.com/indra-labs/indra/pkg/cfg"
 	"github.com/indra-labs/indra/pkg/codec"
 	"github.com/indra-labs/indra/pkg/codec/onion/cores/end"
 	"github.com/indra-labs/indra/pkg/codec/onion/crypt"
@@ -13,8 +14,9 @@ import (
 	"github.com/indra-labs/indra/pkg/engine/sess"
 	"github.com/indra-labs/indra/pkg/engine/sessions"
 	log2 "github.com/indra-labs/indra/pkg/proc/log"
+	"github.com/indra-labs/indra/pkg/util/multi"
 	"github.com/indra-labs/indra/pkg/util/splice"
-	"net/netip"
+	"github.com/multiformats/go-multiaddr"
 	"reflect"
 )
 
@@ -25,7 +27,6 @@ var (
 
 const (
 	Magic = "forw"
-	Len   = magic.Len + 1 + splice.AddrLen
 )
 
 // Forward is a simple forward of the remainder of the onion to a given address
@@ -40,7 +41,7 @@ const (
 //	extension and are weighted equally. Perhaps they should have bandwidth
 //	capacity indications?
 type Forward struct {
-	AddrPort *netip.AddrPort
+	Multiaddr multiaddr.Multiaddr
 	ont.Onion
 }
 
@@ -58,20 +59,21 @@ func (x *Forward) Account(res *sess.Data, sm *sess.Manager,
 
 // Decode a Forward from a provided splice.Splice.
 func (x *Forward) Decode(s *splice.Splice) (e error) {
-	if e = magic.TooShort(s.Remaining(), Len-magic.Len,
+	if e = magic.TooShort(s.Remaining(), magic.Len,
 		Magic); fails(e) {
 		return
 	}
-	s.ReadAddrPort(&x.AddrPort)
+	s.ReadMultiaddr(&x.Multiaddr)
 	return
 }
 
 // Encode a Forward into the next bytes of a splice.Splice.
 func (x *Forward) Encode(s *splice.Splice) error {
 	log.T.F("encoding %s %s", reflect.TypeOf(x),
-		x.AddrPort.String(),
+		x.Multiaddr.String(),
 	)
-	return x.Onion.Encode(s.Magic(Magic).AddrPort(x.AddrPort))
+	return x.Onion.Encode(s.Magic(Magic).
+		Multiaddr(x.Multiaddr, cfg.GetCurrentDefaultPort()))
 }
 
 // Unwrap returns the onion inside this Forward.
@@ -81,7 +83,7 @@ func (x *Forward) Unwrap() interface{} { return x.Onion }
 func (x *Forward) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 	// Forward the whole buffer received onwards. Usually there will be a crypt.Layer
 	// under this which will be unwrapped by the receiver.
-	if ng.Mgr().MatchesLocalNodeAddress(x.AddrPort) {
+	if ng.Mgr().MatchesLocalNodeAddress(x.Multiaddr) {
 		// it is for us, we want to unwrap the next part.
 		ng.HandleMessage(splice.BudgeUp(s), x)
 	} else {
@@ -96,13 +98,19 @@ func (x *Forward) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 			}
 		}
 		// we need to forward this message onion.
-		ng.Mgr().Send(x.AddrPort, splice.BudgeUp(s))
+		ng.Mgr().Send(x.Multiaddr, splice.BudgeUp(s))
 	}
 	return e
 }
 
 // Len returns the length of this Forward message.
-func (x *Forward) Len() int { return Len + x.Onion.Len() }
+func (x *Forward) Len() int {
+	b, _ := multi.AddrToBytes(x.Multiaddr,
+		cfg.GetCurrentDefaultPort())
+	return magic.Len +
+		len(b) + 1 +
+		x.Onion.Len()
+}
 
 // Magic is the identifying 4 byte string indicating an Forward message follows.
 func (x *Forward) Magic() string { return Magic }
@@ -111,7 +119,9 @@ func (x *Forward) Magic() string { return Magic }
 func (x *Forward) Wrap(inner ont.Onion) { x.Onion = inner }
 
 // New creates a new Forward onion.
-func New(addr *netip.AddrPort) ont.Onion { return &Forward{AddrPort: addr, Onion: &end.End{}} }
+func New(addr multiaddr.Multiaddr) ont.Onion {
+	return &Forward{Multiaddr: addr, Onion: &end.End{}}
+}
 
 // Gen is a factory function for a Forward.
 func Gen() codec.Codec { return &Forward{} }

--- a/pkg/codec/onion/forward/forward.go
+++ b/pkg/codec/onion/forward/forward.go
@@ -81,9 +81,13 @@ func (x *Forward) Unwrap() interface{} { return x.Onion }
 
 // Handle is the relay logic for an engine handling a Forward message.
 func (x *Forward) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
-	// Forward the whole buffer received onwards. Usually there will be a crypt.Layer
-	// under this which will be unwrapped by the receiver.
+
+	// Forward the whole buffer received onwards.
+	//
+	// Usually there will be a crypt.Layer under this which will be unwrapped by
+	// the receiver.
 	if ng.Mgr().MatchesLocalNodeAddress(x.Multiaddr) {
+
 		// it is for us, we want to unwrap the next part.
 		ng.HandleMessage(splice.BudgeUp(s), x)
 	} else {

--- a/pkg/codec/onion/forward/forward.go
+++ b/pkg/codec/onion/forward/forward.go
@@ -14,7 +14,6 @@ import (
 	"github.com/indra-labs/indra/pkg/engine/sess"
 	"github.com/indra-labs/indra/pkg/engine/sessions"
 	log2 "github.com/indra-labs/indra/pkg/proc/log"
-	"github.com/indra-labs/indra/pkg/util/multi"
 	"github.com/indra-labs/indra/pkg/util/splice"
 	"github.com/multiformats/go-multiaddr"
 	"reflect"
@@ -112,11 +111,9 @@ func (x *Forward) Len() int {
 
 	codec.MustNotBeNil(x)
 
-	b, _ := multi.AddrToBytes(x.Multiaddr,
-		cfg.GetCurrentDefaultPort())
-	return magic.Len +
-		len(b) + 1 +
-		x.Onion.Len()
+	// b, _ := multi.AddrToBytes(x.Multiaddr,
+	// 	cfg.GetCurrentDefaultPort())
+	return magic.Len + 21 + x.Onion.Len()
 }
 
 // Magic is the identifying 4 byte string indicating an Forward message follows.

--- a/pkg/codec/onion/forward/forward.go
+++ b/pkg/codec/onion/forward/forward.go
@@ -105,6 +105,9 @@ func (x *Forward) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 
 // Len returns the length of this Forward message.
 func (x *Forward) Len() int {
+
+	codec.MustNotBeNil(x)
+
 	b, _ := multi.AddrToBytes(x.Multiaddr,
 		cfg.GetCurrentDefaultPort())
 	return magic.Len +

--- a/pkg/codec/onion/forward/forward_test.go
+++ b/pkg/codec/onion/forward/forward_test.go
@@ -1,9 +1,11 @@
 package forward
 
 import (
+	"github.com/indra-labs/indra"
 	"github.com/indra-labs/indra/pkg/codec"
 	"github.com/indra-labs/indra/pkg/codec/ont"
 	"github.com/indra-labs/indra/pkg/codec/reg"
+	log2 "github.com/indra-labs/indra/pkg/proc/log"
 	"github.com/indra-labs/indra/pkg/util/multi"
 	"github.com/multiformats/go-multiaddr"
 	"math/rand"
@@ -16,7 +18,10 @@ import (
 )
 
 func TestOnions_Forward(t *testing.T) {
-	ipSizes := []int{net.IPv4len, net.IPv6len}
+	if indra.CI == "false" {
+		log2.SetLogLevel(log2.Trace)
+	}
+	ipSizes := []int{net.IPv6len, net.IPv4len}
 	for i := range ipSizes {
 		n := nonce.New()
 		ip := net.IP(n[:ipSizes[i]])
@@ -39,8 +44,10 @@ func TestOnions_Forward(t *testing.T) {
 		if ma, e = multi.AddrFromAddrPort(ap); fails(e) {
 			t.FailNow()
 		}
+		log.D.S("ma", ma)
 		on := ont.Assemble([]ont.Onion{New(ma)})
 		s := codec.Encode(on)
+		log.D.S("forward", s.GetAll().ToBytes())
 		s.SetCursor(0)
 		var onr codec.Codec
 		if onr = reg.Recognise(s); onr == nil {

--- a/pkg/codec/onion/forward/forward_test.go
+++ b/pkg/codec/onion/forward/forward_test.go
@@ -54,7 +54,7 @@ func TestOnions_Forward(t *testing.T) {
 		}
 		var cf *Forward
 		if cf, ok = onr.(*Forward); !ok {
-			t.Error("did not unwrap expected type expected *Reverse got",
+			t.Error("did not unwrap expected type expected *Forward got",
 				reflect.TypeOf(onr))
 			t.FailNow()
 		}

--- a/pkg/codec/onion/forward/forward_test.go
+++ b/pkg/codec/onion/forward/forward_test.go
@@ -40,7 +40,7 @@ func TestOnions_Forward(t *testing.T) {
 			t.FailNow()
 		}
 		on := ont.Assemble([]ont.Onion{New(ma)})
-		s := ont.Encode(on)
+		s := codec.Encode(on)
 		s.SetCursor(0)
 		var onr codec.Codec
 		if onr = reg.Recognise(s); onr == nil {

--- a/pkg/codec/onion/forward/forward_test.go
+++ b/pkg/codec/onion/forward/forward_test.go
@@ -4,6 +4,8 @@ import (
 	"github.com/indra-labs/indra/pkg/codec"
 	"github.com/indra-labs/indra/pkg/codec/ont"
 	"github.com/indra-labs/indra/pkg/codec/reg"
+	"github.com/indra-labs/indra/pkg/util/multi"
+	"github.com/multiformats/go-multiaddr"
 	"math/rand"
 	"net"
 	"net/netip"
@@ -32,9 +34,12 @@ func TestOnions_Forward(t *testing.T) {
 		}
 		port := uint16(rand.Uint32())
 		ap := netip.AddrPortFrom(adr, port)
-		on := ont.Assemble([]ont.Onion{
-			New(&ap),
-		})
+		var ma multiaddr.Multiaddr
+		var e error
+		if ma, e = multi.AddrFromAddrPort(ap); fails(e) {
+			t.FailNow()
+		}
+		on := ont.Assemble([]ont.Onion{New(ma)})
 		s := ont.Encode(on)
 		s.SetCursor(0)
 		var onr codec.Codec
@@ -53,8 +58,7 @@ func TestOnions_Forward(t *testing.T) {
 				reflect.TypeOf(onr))
 			t.FailNow()
 		}
-		if cf.AddrPort.String() != ap.String() {
-			log.I.S(cf.AddrPort, ap)
+		if cf.Multiaddr.String() != ma.String() {
 			t.Error("reverse Addresses did not unwrap correctly")
 			t.FailNow()
 		}

--- a/pkg/codec/onion/getbalance/getbalance.go
+++ b/pkg/codec/onion/getbalance/getbalance.go
@@ -100,7 +100,7 @@ func (x *GetBalance) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error
 	}
 	log.D.Ln("session found", x.ID)
 	header := hidden.GetRoutingHeaderFromCursor(s)
-	rbb := hidden.FormatReply(header, x.Ciphers, x.Nonces, ont.Encode(bal).GetAll())
+	rbb := hidden.FormatReply(header, x.Ciphers, x.Nonces, codec.Encode(bal).GetAll())
 	rb := append(rbb.GetAll(), slice.NoisePad(714-rbb.Len())...)
 	switch on1 := p.(type) {
 	case *crypt.Crypt:
@@ -119,13 +119,19 @@ func (x *GetBalance) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error
 		}
 		return false
 	})
-	rbb = hidden.FormatReply(header, x.Ciphers, x.Nonces, ont.Encode(bal).GetAll())
+	rbb = hidden.FormatReply(header, x.Ciphers, x.Nonces, codec.Encode(bal).GetAll())
 	rb = append(rbb.GetAll(), slice.NoisePad(714-len(rb))...)
 	ng.HandleMessage(splice.Load(rb, slice.NewCursor()), x)
 	return
 }
 
-func (x *GetBalance) Len() int      { return GetBalanceLen + x.Onion.Len() }
+func (x *GetBalance) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return GetBalanceLen + x.Onion.Len()
+}
+
 func (x *GetBalance) Magic() string { return GetBalanceMagic }
 
 type GetBalanceParams struct {

--- a/pkg/codec/onion/getbalance/getbalance_test.go
+++ b/pkg/codec/onion/getbalance/getbalance_test.go
@@ -34,7 +34,7 @@ func TestOnions_GetBalance(t *testing.T) {
 		ReturnPubs: pubs,
 	}
 	on := ont.Assemble([]ont.Onion{NewGetBalance(id, ep)})
-	s := ont.Encode(on)
+	s := codec.Encode(on)
 	s.SetCursor(0)
 	var onc codec.Codec
 	if onc = reg.Recognise(s); onc == nil {

--- a/pkg/codec/onion/hidden/introquery/introquery.go
+++ b/pkg/codec/onion/hidden/introquery/introquery.go
@@ -126,7 +126,12 @@ func (x *IntroQuery) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error
 
 // Len returns the length of the onion starting from this one (used to size a
 // Splice).
-func (x *IntroQuery) Len() int { return Len + x.Onion.Len() }
+func (x *IntroQuery) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len + x.Onion.Len()
+}
 
 // Magic bytes identifying a HiddenService message is up next.
 func (x *IntroQuery) Magic() string { return Magic }

--- a/pkg/codec/onion/hidden/introquery/introquery_test.go
+++ b/pkg/codec/onion/hidden/introquery/introquery_test.go
@@ -39,7 +39,7 @@ func TestOnions_IntroQuery(t *testing.T) {
 		New(id, crypto.DerivePub(prv1), ep),
 		end.NewEnd(),
 	})
-	s := ont.Encode(on)
+	s := codec.Encode(on)
 	s.SetCursor(0)
 	var onc codec.Codec
 	if onc = reg.Recognise(s); onc == nil {

--- a/pkg/codec/onion/hidden/ready/ready.go
+++ b/pkg/codec/onion/hidden/ready/ready.go
@@ -95,7 +95,12 @@ func (x *Ready) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 }
 
 // Len returns the length of the onion starting from this one.
-func (x *Ready) Len() int { return Len }
+func (x *Ready) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len
+}
 
 // Magic bytes identifying a HiddenService message is up next.
 func (x *Ready) Magic() string { return Magic }

--- a/pkg/codec/onion/hidden/route/route.go
+++ b/pkg/codec/onion/hidden/route/route.go
@@ -204,7 +204,7 @@ func (x *Route) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 			crypt.New(rt.Sessions[2].Header.Pub, rt.Sessions[2].Payload.Pub, rt.Keys[2], rt.Nonces[2], 1),
 		}
 		// .RoutingHeader(rt)
-		rHdr := ont.Encode(ont.Assemble(rh))
+		rHdr := codec.Encode(ont.Assemble(rh))
 		rHdr.SetCursor(0)
 		ep := exit.ExitPoint{
 			Routing: rt,
@@ -228,7 +228,7 @@ func (x *Route) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 				ep.Nonces),
 		}
 		assembled := ont.Assemble(mr)
-		reply := ont.Encode(assembled)
+		reply := codec.Encode(assembled)
 		ng.HandleMessage(reply, x)
 	}
 	return

--- a/pkg/codec/onion/hidden/services/hiddenservice.go
+++ b/pkg/codec/onion/hidden/services/hiddenservice.go
@@ -123,7 +123,12 @@ func (x *HiddenService) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e er
 
 // Len returns the length of the onion starting from this one (used to size a
 // Splice).
-func (x *HiddenService) Len() int { return Len + x.Onion.Len() }
+func (x *HiddenService) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len + x.Onion.Len()
+}
 
 // Magic bytes identifying a HiddenService message is up next.
 func (x *HiddenService) Magic() string { return Magic }

--- a/pkg/codec/onion/hidden/whisper/whisper.go
+++ b/pkg/codec/onion/hidden/whisper/whisper.go
@@ -130,7 +130,12 @@ func (x *Message) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 }
 
 // Len returns the length of this Message.
-func (x *Message) Len() int { return MessageLen + x.Payload.Len() }
+func (x *Message) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return MessageLen + x.Payload.Len()
+}
 
 // Magic is the identifying 4 byte string indicating a Message follows.
 func (x *Message) Magic() string { return MessageMagic }

--- a/pkg/codec/onion/hidden/whisper/whisper.go
+++ b/pkg/codec/onion/hidden/whisper/whisper.go
@@ -29,10 +29,20 @@ var (
 )
 
 const (
-	MessageMagic    = "whis"
+	MessageMagic = "whis"
+
+	// ReplyCiphersLen is
+	//
+	// Deprecated: this is now a variable length structure, Reverse is being
+	// obsoleted in favour of Offset.
 	ReplyCiphersLen = 2*consts.RoutingHeaderLen +
 		6*sha256.Len +
 		6*nonce.IVLen
+
+	// MessageLen is
+	//
+	// Deprecated: this is now a variable length structure, Reverse is being
+	// obsoleted in favour of Offset.
 	MessageLen = magic.Len +
 		2*nonce.IDLen +
 		2*consts.RoutingHeaderLen +

--- a/pkg/codec/onion/reverse/reverse.go
+++ b/pkg/codec/onion/reverse/reverse.go
@@ -32,6 +32,8 @@ const (
 
 // Reverse is a part of the 3 layer relay RoutingHeader which provides the next
 // address to forward to.
+//
+// Deprecated: In process of obsoleting this and replacing with offset
 type Reverse struct {
 
 	// AddrPort of the relay to forward this message.

--- a/pkg/codec/onion/reverse/reverse.go
+++ b/pkg/codec/onion/reverse/reverse.go
@@ -145,6 +145,9 @@ func (x *Reverse) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 
 // Len returns the length of this Reverse message.
 func (x *Reverse) Len() int {
+
+	codec.MustNotBeNil(x)
+
 	b, _ := multi.AddrToBytes(x.Multiaddr,
 		cfg.GetCurrentDefaultPort())
 

--- a/pkg/codec/onion/reverse/reverse.go
+++ b/pkg/codec/onion/reverse/reverse.go
@@ -14,7 +14,6 @@ import (
 	"github.com/indra-labs/indra/pkg/engine/sess"
 	"github.com/indra-labs/indra/pkg/engine/sessions"
 	log2 "github.com/indra-labs/indra/pkg/proc/log"
-	"github.com/indra-labs/indra/pkg/util/multi"
 	"github.com/indra-labs/indra/pkg/util/slice"
 	"github.com/indra-labs/indra/pkg/util/splice"
 	"github.com/multiformats/go-multiaddr"
@@ -150,10 +149,10 @@ func (x *Reverse) Len() int {
 
 	codec.MustNotBeNil(x)
 
-	b, _ := multi.AddrToBytes(x.Multiaddr,
-		cfg.GetCurrentDefaultPort())
+	// b, _ := multi.AddrToBytes(x.Multiaddr,
+	// 	cfg.GetCurrentDefaultPort())
 
-	return len(b) + 5 + x.Onion.Len()
+	return magic.Len + 21 + x.Onion.Len()
 }
 
 // Magic is the identifying 4 byte string indicating a Reverse message follows.

--- a/pkg/codec/onion/reverse/reverse_test.go
+++ b/pkg/codec/onion/reverse/reverse_test.go
@@ -40,7 +40,7 @@ func TestOnions_Reverse(t *testing.T) {
 			t.FailNow()
 		}
 		on := ont.Assemble([]ont.Onion{New(ma)})
-		s := ont.Encode(on)
+		s := codec.Encode(on)
 		s.SetCursor(0)
 		var onr codec.Codec
 		if onr = reg.Recognise(s); onr == nil {

--- a/pkg/codec/onion/reverse/reverse_test.go
+++ b/pkg/codec/onion/reverse/reverse_test.go
@@ -1,9 +1,11 @@
 package reverse
 
 import (
+	"github.com/indra-labs/indra"
 	"github.com/indra-labs/indra/pkg/codec"
 	"github.com/indra-labs/indra/pkg/codec/ont"
 	"github.com/indra-labs/indra/pkg/codec/reg"
+	log2 "github.com/indra-labs/indra/pkg/proc/log"
 	"github.com/indra-labs/indra/pkg/util/multi"
 	"github.com/multiformats/go-multiaddr"
 	"math/rand"
@@ -16,6 +18,9 @@ import (
 )
 
 func TestOnions_Reverse(t *testing.T) {
+	if indra.CI == "false" {
+		log2.SetLogLevel(log2.Trace)
+	}
 	ipSizes := []int{net.IPv4len, net.IPv6len}
 	for i := range ipSizes {
 		n := nonce.New()

--- a/pkg/codec/onion/reverse/reverse_test.go
+++ b/pkg/codec/onion/reverse/reverse_test.go
@@ -4,6 +4,8 @@ import (
 	"github.com/indra-labs/indra/pkg/codec"
 	"github.com/indra-labs/indra/pkg/codec/ont"
 	"github.com/indra-labs/indra/pkg/codec/reg"
+	"github.com/indra-labs/indra/pkg/util/multi"
+	"github.com/multiformats/go-multiaddr"
 	"math/rand"
 	"net"
 	"net/netip"
@@ -32,7 +34,12 @@ func TestOnions_Reverse(t *testing.T) {
 		}
 		port := uint16(rand.Uint32())
 		ap := netip.AddrPortFrom(adr, port)
-		on := ont.Assemble([]ont.Onion{New(&ap)})
+		var ma multiaddr.Multiaddr
+		var e error
+		if ma, e = multi.AddrFromAddrPort(ap); fails(e) {
+			t.FailNow()
+		}
+		on := ont.Assemble([]ont.Onion{New(ma)})
 		s := ont.Encode(on)
 		s.SetCursor(0)
 		var onr codec.Codec
@@ -51,8 +58,8 @@ func TestOnions_Reverse(t *testing.T) {
 				reflect.TypeOf(onr))
 			t.FailNow()
 		}
-		if cf.AddrPort.String() != ap.String() {
-			log.I.S(cf.AddrPort, ap)
+		if cf.Multiaddr.String() != ma.String() {
+			log.I.S(cf.Multiaddr, ap)
 			t.Error("reverse Addresses did not unwrap correctly")
 			t.FailNow()
 		}

--- a/pkg/codec/onion/session/session.go
+++ b/pkg/codec/onion/session/session.go
@@ -127,7 +127,12 @@ func (x *Session) Handle(s *splice.Splice, p ont.Onion, ng ont.Ngin) (e error) {
 }
 
 // Len returns the length of this Session message.
-func (x *Session) Len() int { return Len + x.Onion.Len() }
+func (x *Session) Len() int {
+
+	codec.MustNotBeNil(x)
+
+	return Len + x.Onion.Len()
+}
 
 // Magic is the identifying 4 byte string indicating a Session message follows.
 func (x *Session) Magic() string { return Magic }

--- a/pkg/codec/onion/session/session_test.go
+++ b/pkg/codec/onion/session/session_test.go
@@ -3,7 +3,6 @@ package session
 import (
 	"github.com/indra-labs/indra"
 	"github.com/indra-labs/indra/pkg/codec"
-	"github.com/indra-labs/indra/pkg/codec/ont"
 	"github.com/indra-labs/indra/pkg/codec/reg"
 	"testing"
 
@@ -16,7 +15,7 @@ func TestOnions_Session(t *testing.T) {
 	}
 	sess := New(1)
 	ss := sess.(*Session)
-	s := ont.Encode(sess)
+	s := codec.Encode(sess)
 	s.SetCursor(0)
 	var onc codec.Codec
 	if onc = reg.Recognise(s); onc == nil {

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -19,11 +19,11 @@ import (
 
 const (
 	// BlindLen is the length of the blinding factor in bytes for a Cloak.
-	BlindLen = 3
+	BlindLen = 4
 
 	// HashLen is the length from the hash of the key with the Blinder appended to
 	// the Cloak.
-	HashLen = 5
+	HashLen = 4
 
 	// CloakLen is the sum of the Blinder truncated hash from blinder and public key.
 	CloakLen = BlindLen + HashLen
@@ -41,11 +41,12 @@ const (
 
 var (
 	// The key types must satisfy these interfaces for libp2p.
-	_, _  crypto.Key     = &Prv{}, &Pub{}
-	_     crypto.PubKey  = &Pub{}
-	_     crypto.PrivKey = &Prv{}
-	fails                = log.E.Chk
-	log                  = log2.GetLogger()
+	_, _ crypto.Key     = &Prv{}, &Pub{}
+	_    crypto.PubKey  = &Pub{}
+	_    crypto.PrivKey = &Prv{}
+
+	fails = log.E.Chk
+	log   = log2.GetLogger()
 )
 
 // Blinder is the bytes concatenated after a key to generate the Cloak hash.

--- a/pkg/engine/acct.go
+++ b/pkg/engine/acct.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"github.com/indra-labs/indra/pkg/codec"
 	"github.com/indra-labs/indra/pkg/codec/onion/crypt"
 	"github.com/indra-labs/indra/pkg/codec/ont"
 	"github.com/indra-labs/indra/pkg/engine/sess"
@@ -13,7 +14,7 @@ import (
 func PostAcctOnion(sm *sess.Manager, o Skins) (res *sess.Data) {
 	res = &sess.Data{}
 	assembled := ont.Assemble(o)
-	sp := ont.Encode(assembled)
+	sp := codec.Encode(assembled)
 	res.B = sp.GetAll()
 	// do client accounting
 	skip := false

--- a/pkg/engine/consts/hiddenconst.go
+++ b/pkg/engine/consts/hiddenconst.go
@@ -8,8 +8,15 @@ import (
 	"github.com/indra-labs/indra/pkg/util/splice"
 )
 
+// ReverseCryptLen is
+//
+// Deprecated: this is now a variable length structure, Reverse is being
+// obsoleted in favour of Offset.
 const ReverseCryptLen = ReverseLen + CryptLen
 
+// RoutingHeaderLen is
+//
+// Deprecated: this is now a variable length structure.
 const RoutingHeaderLen = 3 * ReverseCryptLen
 
 const CryptLen = magic.Len +
@@ -17,4 +24,7 @@ const CryptLen = magic.Len +
 	crypto.CloakLen +
 	crypto.PubKeyLen
 
+// ReverseLen is
+//
+// Deprecated: Reverse is being obsoleted in favour of Offset.
 const ReverseLen = magic.Len + 1 + splice.AddrLen

--- a/pkg/engine/dispatcher/dispatcher_messages.go
+++ b/pkg/engine/dispatcher/dispatcher_messages.go
@@ -77,6 +77,9 @@ func (a *Acknowledge) Unwrap() interface{} { return nil }
 
 // Len returns the length of an Acknowledge message in bytes.
 func (a *Acknowledge) Len() int {
+
+	codec.MustNotBeNil(a)
+
 	return 4 + nonce.IDLen + sha256.Len + 5*slice.Uint64Len
 }
 
@@ -110,7 +113,12 @@ func (k *NewKey) Encode(s *splice.Splice) (e error) {
 func (k *NewKey) Unwrap() interface{} { return nil }
 
 // Len returns the length of an NewKey message in bytes.
-func (k *NewKey) Len() int { return 4 + crypto.PubKeyLen }
+func (k *NewKey) Len() int {
+
+	codec.MustNotBeNil(k)
+
+	return 4 + crypto.PubKeyLen
+}
 
 // Magic is the identifying 4 byte prefix of an NewKey in binary form.
 func (k *NewKey) Magic() string { return NewKeyMagic }
@@ -139,6 +147,9 @@ func OnionGen() codec.Codec { return &Onion{} }
 func (o *Onion) Unwrap() interface{} { return o.Unpack() }
 
 func (o *Onion) Len() int {
+
+	codec.MustNotBeNil(o)
+
 	return 4 + len(o.Bytes) + 4
 }
 func (o *Onion) Magic() string { return OnionMagic }

--- a/pkg/engine/dispatcher/dispatcher_test.go
+++ b/pkg/engine/dispatcher/dispatcher_test.go
@@ -3,6 +3,7 @@ package dispatcher
 import (
 	"context"
 	"crypto/rand"
+	"github.com/indra-labs/indra/pkg/codec"
 	"github.com/indra-labs/indra/pkg/codec/onion/cores/confirmation"
 	"github.com/indra-labs/indra/pkg/codec/onion/cores/response"
 	"github.com/indra-labs/indra/pkg/crypto/sha256"
@@ -96,8 +97,8 @@ func TestDispatcher(t *testing.T) {
 		confirmation.New(id1)})
 	on2 := ont.Assemble(engine.Skins{
 		response.New(id2, 0, msg1, 0)})
-	s1 := ont.Encode(on1)
-	s2 := ont.Encode(on2)
+	s1 := codec.Encode(on1)
+	s2 := codec.Encode(on2)
 	x1 := s1.GetAll()
 	x2 := s2.GetAll()
 	xx1 := &Onion{x1}

--- a/pkg/engine/magic/magic.go
+++ b/pkg/engine/magic/magic.go
@@ -18,7 +18,7 @@ func TooShort(got, found int, magic string) (e error) {
 	if got >= found {
 		return
 	}
-	e = fmt.Errorf(ErrTooShort, magic, got, found)
+	e = fmt.Errorf(ErrTooShort, magic, found, got)
 	return
 
 }

--- a/pkg/engine/mock.go
+++ b/pkg/engine/mock.go
@@ -13,7 +13,7 @@ import (
 	"github.com/indra-labs/indra/pkg/engine/transport"
 	log2 "github.com/indra-labs/indra/pkg/proc/log"
 	"github.com/indra-labs/indra/pkg/util/slice"
-	"net/netip"
+	"github.com/multiformats/go-multiaddr"
 	"os"
 )
 
@@ -55,7 +55,7 @@ func createNMockCircuits(inclSessions bool, nCircuits int,
 			return
 		}
 		addr := slice.GenerateRandomAddrPortIPv4()
-		nodes[i], _ = node.NewNode([]*netip.AddrPort{addr}, id, tpts[i], 50000)
+		nodes[i], _ = node.NewNode([]multiaddr.Multiaddr{addr}, id, tpts[i], 50000)
 		var l *transport.Listener
 		var dataPath string
 		dataPath, e = os.MkdirTemp(os.TempDir(), "badger")

--- a/pkg/engine/mockengine.go
+++ b/pkg/engine/mockengine.go
@@ -8,9 +8,7 @@ import (
 	"github.com/indra-labs/indra/pkg/crypto/sha256"
 	"github.com/indra-labs/indra/pkg/engine/node"
 	"github.com/indra-labs/indra/pkg/engine/transport"
-	"github.com/indra-labs/indra/pkg/util/multi"
 	"github.com/multiformats/go-multiaddr"
-	"net/netip"
 	"os"
 )
 
@@ -58,13 +56,8 @@ func CreateMockEngine(seed []string, dataPath string, ctx context.Context, cance
 		return
 	}
 
-	var ap netip.AddrPort
-	if ap, e = multi.AddrToAddrPort(ma); fails(e) {
-		return
-	}
-
 	var nod *node.Node
-	if nod, _ = node.NewNode([]*netip.AddrPort{&ap}, k, nil, 50000); fails(e) {
+	if nod, _ = node.NewNode([]multiaddr.Multiaddr{ma}, k, nil, 50000); fails(e) {
 		return
 	}
 	if ng, e = New(Params{

--- a/pkg/engine/peerstore_test.go
+++ b/pkg/engine/peerstore_test.go
@@ -95,7 +95,7 @@ func pauza() {
 
 func TestEngine_PeerStoreDiscovery(t *testing.T) {
 	if indra.CI == "false" {
-		// log2.SetLogLevel(log2.Trace)
+		log2.SetLogLevel(log2.Trace)
 	}
 	const nTotal = 10
 	var (
@@ -125,13 +125,13 @@ func TestEngine_PeerStoreDiscovery(t *testing.T) {
 	for _, v := range engines {
 		// check that all peers now have nTotal-1 distinct peer ads (of all 4
 		// types)
+		var adCount int
 		e = v.PeerstoreView(func(txn *badger.Txn) error {
 			defer txn.Discard()
 			opts := badger.DefaultIteratorOptions
 			it := txn.NewIterator(opts)
 			defer it.Close()
 			var val []byte
-			var adCount int
 			for it.Rewind(); it.Valid(); it.Next() {
 				k := string(it.Item().Key())
 				if !strings.HasSuffix(k, "ad") {
@@ -147,6 +147,7 @@ func TestEngine_PeerStoreDiscovery(t *testing.T) {
 			}
 			return nil
 		})
+		log.D.Ln("entryCount", *entryCount, "adCount", adCount)
 	}
 	if *entryCount != nTotal {
 		t.Log("nodes did not gossip completely to each other, only",

--- a/pkg/engine/reply.go
+++ b/pkg/engine/reply.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"github.com/indra-labs/indra/pkg/codec"
 	"github.com/indra-labs/indra/pkg/codec/onion/exit"
 	"github.com/indra-labs/indra/pkg/codec/ont"
 	"github.com/indra-labs/indra/pkg/crypto"
@@ -21,7 +22,7 @@ func MakeReplyHeader(ng *Engine) (returnHeader *hidden.ReplyHeader) {
 		Nonces:   crypto.Nonces{n[0], n[1], n[2]},
 	}
 	rh := Skins{}.RoutingHeader(rt, ng.Mgr().Protocols)
-	rHdr := ont.Encode(ont.Assemble(rh))
+	rHdr := codec.Encode(ont.Assemble(rh))
 	rHdr.SetCursor(0)
 	ep := exit.ExitPoint{
 		Routing: rt,

--- a/pkg/engine/sess/sessionmanager.go
+++ b/pkg/engine/sess/sessionmanager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/indra-labs/indra/pkg/engine/protocols"
 	"github.com/indra-labs/indra/pkg/util/cryptorand"
+	"github.com/multiformats/go-multiaddr"
 	"net/netip"
 	"sync"
 
@@ -402,12 +403,12 @@ func (sm *Manager) ForEachNode(fn func(n *node.Node) bool) {
 func (sm *Manager) GetLocalNode() *node.Node { return sm.nodes[0] }
 
 // GetLocalNodeAddress returns an Address of the local node. This is done randomly. Only addresses of the types configured in the manager (default is the same as the default gateway's interfaces. IPv4 and maybe IPv6.
-func (sm *Manager) GetLocalNodeAddress() (addr *netip.AddrPort) {
-	//sm.Lock()
-	//defer sm.Unlock()
+func (sm *Manager) GetLocalNodeAddress() (addr multiaddr.Multiaddr) {
+	// sm.Lock()
+	// defer sm.Unlock()
 	addys := sm.nodes[0].
 		Addresses
-	shuf := make([]*netip.AddrPort, len(addys))
+	shuf := make([]multiaddr.Multiaddr, len(addys))
 	for i := range addys {
 		shuf[i] = addys[i]
 	}
@@ -419,15 +420,15 @@ func (sm *Manager) GetLocalNodeAddress() (addr *netip.AddrPort) {
 }
 
 // GetLocalNodeAddresses returns the addresses of the local node.
-func (sm *Manager) GetLocalNodeAddresses() (addr []*netip.AddrPort) {
-	//sm.Lock()
-	//defer sm.Unlock()
+func (sm *Manager) GetLocalNodeAddresses() (addr []multiaddr.Multiaddr) {
+	// sm.Lock()
+	// defer sm.Unlock()
 	return sm.GetLocalNode().Addresses
 }
 
-func (sm *Manager) MatchesLocalNodeAddress(ap *netip.AddrPort) (is bool) {
+func (sm *Manager) MatchesLocalNodeAddress(ap multiaddr.Multiaddr) (is bool) {
 	for _, v := range sm.GetLocalNode().Addresses {
-		if *ap == *v {
+		if ap.Equal(v) {
 			return true
 		}
 	}
@@ -579,14 +580,14 @@ func (sm *Manager) SetLocalNode(n *node.Node) {
 }
 
 // AddLocalNodeAddress changes the local node address.
-func (sm *Manager) AddLocalNodeAddress(addr *netip.AddrPort) {
+func (sm *Manager) AddLocalNodeAddress(addr multiaddr.Multiaddr) {
 	sm.Lock()
 	defer sm.Unlock()
 	sm.GetLocalNode().Addresses = append(sm.GetLocalNode().Addresses, addr)
 }
 
 // AddLocalNodeAddresses changes the local node address.
-func (sm *Manager) AddLocalNodeAddresses(addr []*netip.AddrPort) {
+func (sm *Manager) AddLocalNodeAddresses(addr []multiaddr.Multiaddr) {
 	sm.Lock()
 	defer sm.Unlock()
 	for i := range addr {
@@ -595,12 +596,12 @@ func (sm *Manager) AddLocalNodeAddresses(addr []*netip.AddrPort) {
 }
 
 // RemoveLocalNodeAddress removes a local node address.
-func (sm *Manager) RemoveLocalNodeAddress(addr *netip.AddrPort) {
+func (sm *Manager) RemoveLocalNodeAddress(addr multiaddr.Multiaddr) {
 	sm.Lock()
 	defer sm.Unlock()
-	tmp := make([]*netip.AddrPort, len(sm.nodes[0].Addresses))
+	tmp := make([]multiaddr.Multiaddr, len(sm.nodes[0].Addresses))
 	for _, v := range sm.GetLocalNode().Addresses {
-		if *v != *addr {
+		if v.Equal(addr) {
 			tmp = append(tmp, v)
 		}
 	}

--- a/pkg/hidden/hidden.go
+++ b/pkg/hidden/hidden.go
@@ -126,6 +126,9 @@ func (hr *Hidden) DeleteKnownIntro(key crypto.PubBytes) (
 }
 
 // RoutingHeaderBytes is a raw bytes form of a 3 layer RoutingHeader.
+//
+// Deprecated: This needs to be an alias for []byte as the structure is variable
+// length.
 type RoutingHeaderBytes [consts.RoutingHeaderLen]byte
 
 // Services is a map of local hidden services keyed to their public key.
@@ -266,8 +269,8 @@ type MyIntros map[crypto.PubBytes]*Introduction
 type ReplyHeader struct {
 
 	// RoutingHeaderBytes contains the 3 layer RoutingHeader that holds the path
-	// instructions in three progressively encrypted layers in reverse order so to be
-	// unwrapped progressively.
+	// instructions in three progressively encrypted layers in reverse order so
+	// to be unwrapped progressively.
 	RoutingHeaderBytes
 
 	// Ciphers is a set of 3 symmetric ciphers that are to be used in their

--- a/pkg/util/multi/multiaddr.go
+++ b/pkg/util/multi/multiaddr.go
@@ -70,3 +70,64 @@ func AddKeyToMultiaddr(in multiaddr.Multiaddr, pub *crypto.Pub) (ma multiaddr.Mu
 	ma = in.Encapsulate(k)
 	return
 }
+
+// AddrToBytes takes a multiaddr, strips the ip4/ip6/dns address and port out of
+// it, and recombines it to generate a binary form of the essential network
+// address element of a multiaddr.
+//
+// Note that as mentioned elsewhere, Indra only uses TCP because of the
+// incomplete multi-platform support for QUIC, and a tendency of aggressive
+// network filtering firewalls to prejudicially block UDP traffic.
+func AddrToBytes(ma multiaddr.Multiaddr, defaultPort uint16) (b []byte,
+	e error) {
+
+	// First, read out the values encoded for each of the relevant IP and port
+	// in the value.
+	var ip, port string
+	ip, e = ma.ValueForProtocol(multiaddr.P_IP4)
+	if e != nil || ip == "" {
+		ip, e = ma.ValueForProtocol(multiaddr.P_IP6)
+		if e != nil || ip == "" {
+			ip, e = ma.ValueForProtocol(multiaddr.P_DNS)
+		}
+	}
+	if fails(e) || ip == "" {
+		// There must be DNS, ip4 or ip6 addresses for this field.
+		return
+	}
+	port, e = ma.ValueForProtocol(multiaddr.P_TCP)
+	if fails(e) {
+		return
+	}
+	// If the port is missing, replace it with the defaultPort.
+	if port == "" {
+		var pma multiaddr.Multiaddr
+		pma, e = multiaddr.NewMultiaddr(fmt.Sprintf("/tcp/%d",
+			defaultPort))
+		if fails(e) {
+			// This shouldn't happen.
+			return
+		}
+		port, _ = pma.ValueForProtocol(multiaddr.P_TCP)
+	}
+
+	// Assemble the address and port, and then return the binary form.
+	var mip, port2 multiaddr.Multiaddr
+	mip, e = multiaddr.NewMultiaddr(ip)
+	port2, e = multiaddr.NewMultiaddr(port)
+	return mip.Encapsulate(port2).MarshalBinary()
+}
+
+// BytesToMultiaddr will usually be operating on an encoded value produced by
+// AddrToBytes, meaning it will only encode ip4/ip6/dns and tcp port.
+//
+// It will of course decode any valid protocols encoded in the byte slice, just
+// that the data currently is never encoded into binary with any other data
+// present, mainly because the private key is a distinct identity and is used in
+// Indra for a relay, clients, and hidden services and for now there isn't a
+// multiaddr implementation for indra Hidden Services (there will be!).
+func BytesToMultiaddr(b []byte) (ma multiaddr.Multiaddr,
+	e error) {
+
+	return multiaddr.NewMultiaddrBytes(b)
+}

--- a/pkg/util/multikey/multikey.go
+++ b/pkg/util/multikey/multikey.go
@@ -1,0 +1,27 @@
+package multikey
+
+import (
+	"github.com/indra-labs/indra/pkg/crypto"
+	log2 "github.com/indra-labs/indra/pkg/proc/log"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+)
+
+var (
+	log   = log2.GetLogger()
+	fails = log.E.Chk
+)
+
+func AddKeyToMultiaddr(in multiaddr.Multiaddr, pub *crypto.Pub) (ma multiaddr.Multiaddr) {
+	var pid peer.ID
+	var e error
+	if pid, e = peer.IDFromPublicKey(pub); fails(e) {
+		return
+	}
+	var k multiaddr.Multiaddr
+	if k, e = multiaddr.NewMultiaddr("/p2p/" + pid.String()); fails(e) {
+		return
+	}
+	ma = in.Encapsulate(k)
+	return
+}

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"github.com/indra-labs/indra/pkg/crypto/sha256"
 	log2 "github.com/indra-labs/indra/pkg/proc/log"
+	"github.com/indra-labs/indra/pkg/util/multi"
+	"github.com/multiformats/go-multiaddr"
 	"net/netip"
 	"reflect"
 	"unsafe"
@@ -219,7 +221,7 @@ func (b Bytes) ToU64Slice() (u U64Slice) {
 	return
 }
 
-func GenerateRandomAddrPortIPv4() (ap *netip.AddrPort) {
+func GenerateRandomAddrPortIPv4() (ap multiaddr.Multiaddr) {
 	a := netip.AddrPort{}
 	b := make([]byte, 7)
 	_, e := rand.Read(b)
@@ -229,7 +231,8 @@ func GenerateRandomAddrPortIPv4() (ap *netip.AddrPort) {
 	port := DecodeUint16(b[5:7])
 	str := fmt.Sprintf("%d.%d.%d.%d:%d", b[1], b[2], b[3], b[4], port)
 	a, e = netip.ParseAddrPort(str)
-	return &a
+	ap, e = multi.AddrFromAddrPort(a)
+	return ap
 }
 
 func GenerateRandomAddrPortIPv6() (ap *netip.AddrPort) {

--- a/pkg/util/splice/splice.go
+++ b/pkg/util/splice/splice.go
@@ -19,6 +19,9 @@ import (
 	"time"
 )
 
+// AddrLen is
+//
+// Deprecated: this is now a variable length structure.
 const AddrLen = net.IPv6len + 2
 
 var (

--- a/pkg/util/splice/splice.go
+++ b/pkg/util/splice/splice.go
@@ -96,6 +96,21 @@ func (s *Splice) ReadAddrPort(ap **netip.AddrPort) *Splice {
 	return s
 }
 
+func (s *Splice) RawBytes(b []byte) *Splice {
+	copy(s.b[*s.c:s.c.Inc(len(b))], b)
+	s.Segments = append(s.Segments,
+		NameOffset{Offset: int(*s.c), Name: "raw bytes"})
+	return s
+}
+
+func (s *Splice) ReadRawBytes(b *slice.Bytes) *Splice {
+	bytesLen := slice.DecodeUint32(s.b[*s.c:s.c.Inc(slice.Uint32Len)])
+	*b = s.b[*s.c:s.c.Inc(bytesLen)]
+	s.Segments = append(s.Segments,
+		NameOffset{Offset: int(*s.c), Name: "raw bytes"})
+	return s
+}
+
 func (s *Splice) Multiaddr(a multiaddr.Multiaddr,
 	defaultPort uint16) *Splice {
 
@@ -103,7 +118,7 @@ func (s *Splice) Multiaddr(a multiaddr.Multiaddr,
 	if fails(e) {
 		return s
 	}
-	s.Byte(byte(len(b))).Bytes(b)
+	s.Byte(byte(len(b))).RawBytes(b)
 	return s
 }
 
@@ -131,18 +146,6 @@ func (s *Splice) Byte(b byte) *Splice {
 	s.c.Inc(1)
 	s.Segments = append(s.Segments,
 		NameOffset{Offset: int(*s.c), Name: "byte"})
-	return s
-}
-
-func (s *Splice) Bytes(b []byte) *Splice {
-	bytesLen := slice.NewUint32()
-	slice.EncodeUint32(bytesLen, len(b))
-	copy(s.b[*s.c:s.c.Inc(slice.Uint32Len)], bytesLen)
-	s.Segments = append(s.Segments,
-		NameOffset{Offset: int(*s.c), Name: "32 bit length"})
-	copy(s.b[*s.c:s.c.Inc(len(b))], b)
-	s.Segments = append(s.Segments,
-		NameOffset{Offset: int(*s.c), Name: "bytes"})
 	return s
 }
 
@@ -317,6 +320,18 @@ func (s *Splice) ReadByte(b *byte) *Splice {
 	s.c.Inc(1)
 	s.Segments = append(s.Segments,
 		NameOffset{Offset: int(*s.c), Name: "byte"})
+	return s
+}
+
+func (s *Splice) Bytes(b []byte) *Splice {
+	bytesLen := slice.NewUint32()
+	slice.EncodeUint32(bytesLen, len(b))
+	copy(s.b[*s.c:s.c.Inc(slice.Uint32Len)], bytesLen)
+	s.Segments = append(s.Segments,
+		NameOffset{Offset: int(*s.c), Name: "32 bit length"})
+	copy(s.b[*s.c:s.c.Inc(len(b))], b)
+	s.Segments = append(s.Segments,
+		NameOffset{Offset: int(*s.c), Name: "bytes"})
 	return s
 }
 


### PR DESCRIPTION
This change preserves the existing fixed length based on the size of an IPv6 address, plus one byte length prefix, of 21, and removes all instances of `netip.AddrPort` in favour of a uniform use of `multiaddr.Multiaddr`.

It is planned to later properly deal with variable length addresses, since there may be a need for other formats with longer or shorter encodings, but this achieves the main goal of this issue, which is to eliminate the two different ways and make them all follow one.

All tests pass same as prior to the changes. There is a few stray minor things like altering the blinder length in the cloaked receiver public key to 4:4 instead of the prior 3:5.

This change also brings enforcement of the contract of panic with nil onions, required for the later change that will come with the addition of the Offset field to the Crypt.